### PR TITLE
CronJob minimum resource allocations

### DIFF
--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -57,6 +57,17 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, s
 	headersString = headersString + " -H \"event-time: " + timestamp.String() + "\""
 	headersString = headersString + " -H \"event-type: application/json\""
 	headersString = headersString + " -H \"event-namespace: cronjobtrigger.kubeless.io\""
+
+	resource = {
+		v1.ResourceMemory: "32Ki",
+		v1.ResourceCPU:    "1m",
+	}
+
+	resources = v1.ResourceRequirements{
+		Limits:   resource,
+		Requests: resource,
+	}
+
 	job := &batchv1beta1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            jobName,
@@ -76,9 +87,10 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, s
 							ImagePullSecrets: reqImagePullSecret,
 							Containers: []v1.Container{
 								{
-									Image: reqImage,
-									Name:  "trigger",
-									Args:  []string{"curl", "-Lv", headersString, fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.ObjectMeta.Name, funcObj.ObjectMeta.Namespace)},
+									Image:      reqImage,
+									Name:       "trigger",
+									Args:       []string{"curl", "-Lv", headersString, fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.ObjectMeta.Name, funcObj.ObjectMeta.Namespace)},
+									Resources:  resources,
 								},
 							},
 							RestartPolicy: v1.RestartPolicyNever,

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -83,11 +83,11 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, s
 									Args:  []string{"curl", "-Lv", headersString, fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.ObjectMeta.Name, funcObj.ObjectMeta.Namespace)},
 									Resources: v1.ResourceRequirements{
 										Limits: v1.ResourceList{
-											v1.ResourceMemory: resource.MustParse("32Ki"),
+											v1.ResourceMemory: resource.MustParse("4Mi"),
 											v1.ResourceCPU:    resource.MustParse("1m"),
 										},
 										Requests: v1.ResourceList{
-											v1.ResourceMemory: resource.MustParse("32Ki"),
+											v1.ResourceMemory: resource.MustParse("4Mi"),
 											v1.ResourceCPU:    resource.MustParse("1m"),
 										},
 									},

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -26,9 +26,9 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // EnsureCronJob creates/updates a function cron job
@@ -78,17 +78,17 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, s
 							ImagePullSecrets: reqImagePullSecret,
 							Containers: []v1.Container{
 								{
-									Image:      reqImage,
-									Name:       "trigger",
-									Args:       []string{"curl", "-Lv", headersString, fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.ObjectMeta.Name, funcObj.ObjectMeta.Namespace)},
+									Image: reqImage,
+									Name:  "trigger",
+									Args:  []string{"curl", "-Lv", headersString, fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.ObjectMeta.Name, funcObj.ObjectMeta.Namespace)},
 									Resources: v1.ResourceRequirements{
 										Limits: v1.ResourceList{
 											v1.ResourceMemory: resource.MustParse("32Ki"),
-											v1.ResourceCPU: resource.MustParse("1m"),
+											v1.ResourceCPU:    resource.MustParse("1m"),
 										},
 										Requests: v1.ResourceList{
 											v1.ResourceMemory: resource.MustParse("32Ki"),
-											v1.ResourceCPU: resource.MustParse("1m"),
+											v1.ResourceCPU:    resource.MustParse("1m"),
 										},
 									},
 								},


### PR DESCRIPTION
**Issue Ref**: Fixes https://github.com/kubeless/cronjob-trigger/issues/4
 
**Description**: 
Adding the minimum resource as below to pass through the quota restrictions of the namespace for the trigger pod initialization. Background provided in the following issues:
- https://github.com/kubeless/cronjob-trigger/issues/4
- https://github.com/kubeless/kubeless/issues/960
```diff
+ 	Resources: v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("32Ki"),
+			v1.ResourceCPU:    resource.MustParse("1m"),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("32Ki"),
+			v1.ResourceCPU:    resource.MustParse("1m"),
+		},
+	},
```


**TODOs**:
 - [X] Ready to review
 - [x] Automated Tests
 - [ ] Docs
