### PR TITLE
raised memory limit of cronjob pod to 8Mi, 4Mi limit created sandbox …

### DIFF
--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -83,7 +83,7 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, s
 									Args:  []string{"curl", "-Lv", headersString, fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.ObjectMeta.Name, funcObj.ObjectMeta.Namespace)},
 									Resources: v1.ResourceRequirements{
 										Limits: v1.ResourceList{
-											v1.ResourceMemory: resource.MustParse("4Mi"),
+											v1.ResourceMemory: resource.MustParse("8Mi"),
 											v1.ResourceCPU:    resource.MustParse("1m"),
 										},
 										Requests: v1.ResourceList{


### PR DESCRIPTION
…rpc errors on container startup most of the times

**Issue Ref**: Closes #7 
**Description**: 
4Mi as memory limit was too low on k8s version 1.12.0+
This created "Sandbox RPC" errors on container startup.
Only 1 out of 100 to 1000 times the container was able to start.
[PR Description]
Raised memory limit to 8Mi, request memory is still 4Mi.
This removed all issues, the container is able to start correctly in under 15 seconds and perform curl to the correct function
**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [ ] Docs
