### PR TITLE
Bug: Header args are static and not being parsed

### DIFF
--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -52,7 +52,7 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, s
 	eventId := "\"event-id: $(POD_UID)\""
 	eventTime := "\"event-time: $(date --rfc-3339=seconds --utc)\""
 	eventType := "\"event-type: application/json\""
-	eventNamespace := "\"cronjobtrigger.kubeless.io\""
+	eventNamespace := "\"event-namespace: cronjobtrigger.kubeless.io\""
 	commandTemplate := "curl -Lv -H %s -H %s -H %s -H %s %s"
 
 	command := fmt.Sprintf(commandTemplate, eventId, eventTime, eventType, eventNamespace, functionEndpoint)

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -49,7 +49,7 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, s
 	jobName := fmt.Sprintf("trigger-%s", funcObj.ObjectMeta.Name)
 	functionEndpoint := fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.ObjectMeta.Name, funcObj.ObjectMeta.Namespace)
 
-	eventId := "\"event-id: $(JOB_NAME)\""
+	eventId := "\"event-id: $(POD_UID)\""
 	eventTime := "\"event-time: $(date --rfc-3339=seconds --utc)\""
 	eventType := "\"event-type: application/json\""
 	eventNamespace := "\"cronjobtrigger.kubeless.io\""
@@ -80,10 +80,10 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, s
 									Name:  "trigger",
 									Env: []v1.EnvVar{
 										{
-											Name: "JOB_NAME",
+											Name: "POD_UID",
 											ValueFrom: &v1.EnvVarSource{
 												FieldRef: &v1.ObjectFieldSelector{
-													FieldPath: "metadata.name",
+													FieldPath: "metadata.uid",
 												},
 											},
 										},

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -92,7 +92,7 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, s
 										"/bin/sh",
 										"-c",
 									},
-									Args:  []string{
+									Args: []string{
 										command,
 									},
 									Resources: v1.ResourceRequirements{


### PR DESCRIPTION
## ☕ Purpose

During the development of the integration between my infrastructure and Kubeless I've discovered two big issues with CronJob Trigger:

1. It was not passing the `event-time` and other event args to the triggered function
2. The `event-time` and `event-id` where static, since they're being generated only during the creation of the `CronJob` and not the `pods`

On this PR I'm fixing both issues.

## 🧐 Checklist

- [x] Fixed the header args
- [x] Fixed the event-time static time by providing it from a `date` command executed alongside with the `curl` on the container
- [x] Fixed the event-id static ID by providing it on an environment variable referencing to the `metadata.uuid` key
- [x] Updated automated tests

## 🐞 Testing

You can test it with my custom image: `odelucca/cronjob-trigger-controller`