### PR TITLE
Feature: Add payload option to trigger

### DIFF
--- a/pkg/apis/kubeless/v1beta1/cronjob_trigger.go
+++ b/pkg/apis/kubeless/v1beta1/cronjob_trigger.go
@@ -32,9 +32,9 @@ type CronJobTrigger struct {
 
 // CronJobTriggerSpec defines specification for CronJobTrigger
 type CronJobTriggerSpec struct {
-	Schedule     string `json:"schedule"`      // Scheduled time (for Schedule type)
-	FunctionName string `json:"function-name"` // Name of the associated function
-	Payload      interface{} `json:"payload"` // Payload to send as the request data to the given function
+	Schedule     string      `json:"schedule"`      // Scheduled time (for Schedule type)
+	FunctionName string      `json:"function-name"` // Name of the associated function
+	Payload      interface{} `json:"payload"`       // Payload to send as the request data to the given function
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/kubeless/v1beta1/cronjob_trigger.go
+++ b/pkg/apis/kubeless/v1beta1/cronjob_trigger.go
@@ -34,6 +34,7 @@ type CronJobTrigger struct {
 type CronJobTriggerSpec struct {
 	Schedule     string `json:"schedule"`      // Scheduled time (for Schedule type)
 	FunctionName string `json:"function-name"` // Name of the associated function
+	Payload      interface{} `json:"payload"` // Payload to send as the request data to the given function
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/cronjob_trigger_controller.go
+++ b/pkg/controller/cronjob_trigger_controller.go
@@ -255,7 +255,7 @@ func (c *CronJobTriggerController) syncCronJobTrigger(key string) error {
 		c.logger.Errorf("Unable to find the function %s in the namespace %s. Received %s: ", cronJobtriggerObj.Spec.FunctionName, ns, err)
 		return err
 	}
-	err = cronjobutils.EnsureCronJob(c.clientset, functionObj, cronJobtriggerObj.Spec.Schedule, c.config.Data["provision-image"], or, c.imagePullSecrets)
+	err = cronjobutils.EnsureCronJob(c.clientset, functionObj, cronJobtriggerObj, c.config.Data["provision-image"], or, c.imagePullSecrets)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -52,7 +52,7 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, s
 	eventId := "\"event-id: $(POD_UID)\""
 	eventTime := "\"event-time: $(date --rfc-3339=seconds --utc)\""
 	eventType := "\"event-type: application/json\""
-	eventNamespace := "\"cronjobtrigger.kubeless.io\""
+	eventNamespace := "\"event-namespace: cronjobtrigger.kubeless.io\""
 	commandTemplate := "curl -Lv -H %s -H %s -H %s -H %s %s"
 
 	command := fmt.Sprintf(commandTemplate, eventId, eventTime, eventType, eventNamespace, functionEndpoint)

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -17,12 +17,12 @@ limitations under the License.
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
-	"encoding/json"
 
-	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
 	cronjobTriggerApi "github.com/kubeless/cronjob-trigger/pkg/apis/kubeless/v1beta1"
+	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -49,7 +49,7 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, s
 	jobName := fmt.Sprintf("trigger-%s", funcObj.ObjectMeta.Name)
 	functionEndpoint := fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.ObjectMeta.Name, funcObj.ObjectMeta.Namespace)
 
-	eventId := "\"event-id: $(JOB_NAME)\""
+	eventId := "\"event-id: $(POD_UID)\""
 	eventTime := "\"event-time: $(date --rfc-3339=seconds --utc)\""
 	eventType := "\"event-type: application/json\""
 	eventNamespace := "\"cronjobtrigger.kubeless.io\""
@@ -80,10 +80,10 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, s
 									Name:  "trigger",
 									Env: []v1.EnvVar{
 										{
-											Name: "JOB_NAME",
+											Name: "POD_UID",
 											ValueFrom: &v1.EnvVarSource{
 												FieldRef: &v1.ObjectFieldSelector{
-													FieldPath: "metadata.name",
+													FieldPath: "metadata.uid",
 												},
 											},
 										},

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -92,7 +92,7 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, s
 										"/bin/sh",
 										"-c",
 									},
-									Args:  []string{
+									Args: []string{
 										command,
 									},
 									Resources: v1.ResourceRequirements{

--- a/pkg/utils/kubelessutil_test.go
+++ b/pkg/utils/kubelessutil_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
+	cronjobTriggerApi "github.com/kubeless/cronjob-trigger/pkg/apis/kubeless/v1beta1"
 
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
@@ -23,6 +24,7 @@ func TestEnsureCronJob(t *testing.T) {
 	}
 	ns := "default"
 	f1Name := "func1"
+	newSchedule := "* * * * *"
 	f1 := &kubelessApi.Function{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      f1Name,
@@ -30,6 +32,11 @@ func TestEnsureCronJob(t *testing.T) {
 		},
 		Spec: kubelessApi.FunctionSpec{
 			Timeout: "120",
+		},
+	}
+	cronjobTriggerObj := &cronjobTriggerApi.CronJobTrigger{
+		Spec: cronjobTriggerApi.CronJobTriggerSpec{
+			Schedule: newSchedule,
 		},
 	}
 	expectedMeta := metav1.ObjectMeta{
@@ -44,7 +51,7 @@ func TestEnsureCronJob(t *testing.T) {
 	pullSecrets := []v1.LocalObjectReference{
 		{Name: "creds"},
 	}
-	err := EnsureCronJob(clientset, f1, "* * * * *", "unzip", or, pullSecrets)
+	err := EnsureCronJob(clientset, f1, cronjobTriggerObj, "unzip", or, pullSecrets)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -85,9 +92,28 @@ func TestEnsureCronJob(t *testing.T) {
 		t.Errorf("Unexpected command %s expexted %s", foundCommand, expectedCommand)
 	}
 
-	// It should update the existing cronJob if it is already created
-	newSchedule := "*/10 * * * *"
-	err = EnsureCronJob(clientset, f1, newSchedule, "unzip", or, pullSecrets)
+	newSchedule = "*/10 * * * *"
+	newData := make(map[string]string)
+	newData["test"] = "foo"
+
+	cronjobTriggerObj.Spec.Schedule = newSchedule
+	cronjobTriggerObj.Spec.Payload = newData
+
+	err = EnsureCronJob(clientset, f1, cronjobTriggerObj, "unzip", or, pullSecrets)
+	cronJob, err = clientset.BatchV1beta1().CronJobs(ns).Get(fmt.Sprintf("trigger-%s", f1.Name), metav1.GetOptions{})
+
+	runtimeContainer = cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+	args = runtimeContainer.Args
+	foundCommand = args[0]
+
+	expectedData := "{\"test\":\"foo\"}"
+	expectedHeaders = fmt.Sprintf("-H %s -H %s -H %s -H %s -d %s", expectedId, expectedTime, expectedType, expectedNamespace, expectedData)
+	expectedCommand = fmt.Sprintf("curl -Lv %s %s", expectedHeaders, expectedEndpoint)
+
+	if !reflect.DeepEqual(foundCommand, expectedCommand) {
+		t.Errorf("Unexpected command %s expexted %s", foundCommand, expectedCommand)
+	}
+
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -104,6 +130,7 @@ func TestAvoidCronjobOverwrite(t *testing.T) {
 	or := []metav1.OwnerReference{}
 	ns := "default"
 	f1Name := "func1"
+	newSchedule := "* * * * *"
 	f1 := &kubelessApi.Function{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      f1Name,
@@ -111,12 +138,18 @@ func TestAvoidCronjobOverwrite(t *testing.T) {
 		},
 		Spec: kubelessApi.FunctionSpec{},
 	}
+	cronjobTriggerObj := &cronjobTriggerApi.CronJobTrigger{
+		Spec: cronjobTriggerApi.CronJobTriggerSpec{
+			Schedule: newSchedule,
+		},
+	}
+
 	clientset := fake.NewSimpleClientset()
 
 	clientset.BatchV1beta1().CronJobs(ns).Create(&batchv1beta1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("trigger-%s", f1.Name)},
 	})
-	err := EnsureCronJob(clientset, f1, "* * * * *", "unzip", or, []v1.LocalObjectReference{})
+	err := EnsureCronJob(clientset, f1, cronjobTriggerObj, "unzip", or, []v1.LocalObjectReference{})
 	if err == nil && strings.Contains(err.Error(), "conflicting object") {
 		t.Errorf("It should fail because a conflict")
 	}

--- a/pkg/utils/kubelessutil_test.go
+++ b/pkg/utils/kubelessutil_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
 	cronjobTriggerApi "github.com/kubeless/cronjob-trigger/pkg/apis/kubeless/v1beta1"
+	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
 
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"

--- a/pkg/utils/kubelessutil_test.go
+++ b/pkg/utils/kubelessutil_test.go
@@ -72,12 +72,13 @@ func TestEnsureCronJob(t *testing.T) {
 		t.Errorf("Unexpected ActiveDeadlineSeconds: %d", *cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds)
 	}
 
-	expectedId := "\"event-id: $(POD_UID)\""
-	expectedTime := "\"event-time: $(date --rfc-3339=seconds --utc)\""
-	expectedType := "\"event-type: application/json\""
-	expectedNamespace := "\"event-namespace: cronjobtrigger.kubeless.io\""
+	expectedId := "\"Event-Id: $(POD_UID)\""
+	expectedTime := "\"Event-Time: $(date --rfc-3339=seconds --utc)\""
+	expectedNamespace := "\"Event-Namespace: cronjobtrigger.kubeless.io\""
+	expectedType := "\"Event-Type: application/json\""
+	contentType := "\"Content-Type: application/json\""
 
-	expectedHeaders := fmt.Sprintf("-H %s -H %s -H %s -H %s", expectedId, expectedTime, expectedType, expectedNamespace)
+	expectedHeaders := fmt.Sprintf("-H %s -H %s -H %s -H %s -H %s", expectedId, expectedTime, expectedNamespace, expectedType, contentType)
 	expectedEndpoint := fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", f1Name, ns)
 	expectedCommand := fmt.Sprintf("curl -Lv %s %s", expectedHeaders, expectedEndpoint)
 
@@ -106,9 +107,8 @@ func TestEnsureCronJob(t *testing.T) {
 	args = runtimeContainer.Args
 	foundCommand = args[0]
 
-	expectedData := "{\"test\":\"foo\"}"
-	expectedHeaders = fmt.Sprintf("-H %s -H %s -H %s -H %s -d %s", expectedId, expectedTime, expectedType, expectedNamespace, expectedData)
-	expectedCommand = fmt.Sprintf("curl -Lv %s %s", expectedHeaders, expectedEndpoint)
+	expectedData := "-d '{\"test\":\"foo\"}'"
+	expectedCommand = fmt.Sprintf("curl -Lv %s %s %s", expectedHeaders, expectedEndpoint, expectedData)
 
 	if !reflect.DeepEqual(foundCommand, expectedCommand) {
 		t.Errorf("Unexpected command %s expexted %s", foundCommand, expectedCommand)


### PR DESCRIPTION
## ☕ Purpose

During the implementation of a function on our infrastructure we stumbled upon the requirement to pass a payload in a CronJob trigger. On this PR I'm adding that feature.

## 🧐 Checklist

- [x] Changed the controller to pass the entire `CronJobTrigger` object, instead of just the schedule
- [x] Changed the utils to parse the `payload' option of the object (if exists)
- [x] Updated the tests

## 🐞 Testing

You can test it with my custom image: `odelucca/cronjob-trigger-controller`

## 🔗 Related PRs

This PR **requires** that #11 should be merged first, because it is using that PR as it's base.