### PR TITLE
Feature: Merges CronJobTrigger and Function metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7 // indirect
 	github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880 // indirect
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c // indirect
-	github.com/imdario/mergo v0.0.0-20180119215619-163f41321a19 // indirect
+	github.com/imdario/mergo v0.0.0-20180119215619-163f41321a19
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v0.0.0-20170829155851-36b14963da70 // indirect
 	github.com/juju/ratelimit v0.0.0-20170523012141-5b9ff8664717 // indirect

--- a/pkg/utils/kubelessutil_test.go
+++ b/pkg/utils/kubelessutil_test.go
@@ -136,9 +136,9 @@ func TestEnsureCronJob(t *testing.T) {
 	expectedData := "-d '{\"test\":\"foo\"}'"
 	expectedCommand = fmt.Sprintf("curl -Lv %s %s %s", expectedHeaders, expectedEndpoint, expectedData)
 
-	// if !reflect.DeepEqual(foundCommand, expectedCommand) {
-	// 	t.Errorf("Unexpected command %s expected %s", foundCommand, expectedCommand)
-	// }
+	if !reflect.DeepEqual(foundCommand, expectedCommand) {
+		t.Errorf("Unexpected command %s expected %s", foundCommand, expectedCommand)
+	}
 
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)

--- a/pkg/utils/kubelessutil_test.go
+++ b/pkg/utils/kubelessutil_test.go
@@ -29,12 +29,29 @@ func TestEnsureCronJob(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      f1Name,
 			Namespace: ns,
+			Labels: map[string]string{
+				"test":    "true",
+				"only-fn": "ok",
+			},
+			Annotations: map[string]string{
+				"kubeless.io/test":          "test",
+				"kubeless.io/function-only": "this should exist",
+			},
 		},
 		Spec: kubelessApi.FunctionSpec{
 			Timeout: "120",
 		},
 	}
 	cronjobTriggerObj := &cronjobTriggerApi.CronJobTrigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"test": "false",
+			},
+			Annotations: map[string]string{
+				"kubeless.io/test": "not a test",
+				"kubeless.io/new":  "new",
+			},
+		},
 		Spec: cronjobTriggerApi.CronJobTriggerSpec{
 			Schedule: newSchedule,
 		},
@@ -43,7 +60,16 @@ func TestEnsureCronJob(t *testing.T) {
 		Name:            "trigger-" + f1Name,
 		Namespace:       ns,
 		OwnerReferences: or,
-		Labels:          addDefaultLabel(map[string]string{}),
+		Labels: map[string]string{
+			"test":       "false",
+			"only-fn":    "ok",
+			"created-by": "kubeless",
+		},
+		Annotations: map[string]string{
+			"kubeless.io/test":          "not a test",
+			"kubeless.io/function-only": "this should exist",
+			"kubeless.io/new":           "new",
+		},
 	}
 
 	clientset := fake.NewSimpleClientset()
@@ -110,9 +136,9 @@ func TestEnsureCronJob(t *testing.T) {
 	expectedData := "-d '{\"test\":\"foo\"}'"
 	expectedCommand = fmt.Sprintf("curl -Lv %s %s %s", expectedHeaders, expectedEndpoint, expectedData)
 
-	if !reflect.DeepEqual(foundCommand, expectedCommand) {
-		t.Errorf("Unexpected command %s expexted %s", foundCommand, expectedCommand)
-	}
+	// if !reflect.DeepEqual(foundCommand, expectedCommand) {
+	// 	t.Errorf("Unexpected command %s expected %s", foundCommand, expectedCommand)
+	// }
 
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
@@ -152,5 +178,28 @@ func TestAvoidCronjobOverwrite(t *testing.T) {
 	err := EnsureCronJob(clientset, f1, cronjobTriggerObj, "unzip", or, []v1.LocalObjectReference{})
 	if err == nil && strings.Contains(err.Error(), "conflicting object") {
 		t.Errorf("It should fail because a conflict")
+	}
+}
+
+func TestMergeMaps(t *testing.T) {
+	fnMap := map[string]string{
+		"fnOverwritten": "nok",
+		"fnUntouched":   "ok",
+		"tgUntouched":   "nok",
+	}
+	tgMap := map[string]string{
+		"fnOverwritten": "ok",
+		"tgUntouched":   "ok",
+	}
+	expected := map[string]string{
+		"fnOverwritten": "ok",
+		"fnUntouched":   "ok",
+		"tgUntouched":   "ok",
+	}
+
+	result := mergeMaps(tgMap, fnMap)
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Unexpected merged result: \n Expecting: \n %s \n Received: \n %s", expected, result)
 	}
 }


### PR DESCRIPTION
## ☕ Purpose

During the testing of the CronJobTrigger on QuintoAndar's infrastructure, I've found out that `cronjob-trigger-controller` is not passing any `Annotations` or `Labels` from the `CronJobTrigger` resource to the `CronJob` resource (and `Job` too).

This is a problem since we need to remove the Istio sidecar to run our Jobs without issues. Istio sidecar can only be removed from a resource by adding an annotation to it, and that annotations was not being passed down to the Job itself.

On this commit I've fixed that by adding a `merge` step to merge the `metadata.labels` and `metadata.annotations` of `Function` and `CronJobTrigger` and pass that merged data to the `CronJob` resource and it's template.

## 🧐 Checklist

- [x] Developed new tests
- [x] Developed a `mergeMaps` function
- [x] Create the merged `labels` and `annotations`
- [x] Added those metadata to the `CronJob` resource and it's template
- [x] While adding labels, added the `addDefaultLabel` to append the `created-by` label

## 🐞 Testing

You can test this controller using my own custom image: `odelucca/cronjob-trigger-controller:v1.0.3`