### PR TITLE
Bug: Can't create multiple triggers to same function

### DIFF
--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -59,7 +59,7 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, c
 	}
 
 	activeDeadlineSeconds := int64(timeout)
-	jobName := fmt.Sprintf("trigger-%s", funcObj.ObjectMeta.Name)
+	jobName := cronjobTriggerObj.ObjectMeta.Name
 	functionEndpoint := fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.ObjectMeta.Name, funcObj.ObjectMeta.Namespace)
 
 	headersTemplate := "-H %s -H %s -H %s -H %s -H %s"

--- a/pkg/utils/kubelessutil_test.go
+++ b/pkg/utils/kubelessutil_test.go
@@ -24,6 +24,7 @@ func TestEnsureCronJob(t *testing.T) {
 	}
 	ns := "default"
 	f1Name := "func1"
+	cronjobName := "cron-func1"
 	newSchedule := "* * * * *"
 	f1 := &kubelessApi.Function{
 		ObjectMeta: metav1.ObjectMeta{
@@ -44,6 +45,7 @@ func TestEnsureCronJob(t *testing.T) {
 	}
 	cronjobTriggerObj := &cronjobTriggerApi.CronJobTrigger{
 		ObjectMeta: metav1.ObjectMeta{
+			Name: cronjobName,
 			Labels: map[string]string{
 				"test": "false",
 			},
@@ -57,7 +59,7 @@ func TestEnsureCronJob(t *testing.T) {
 		},
 	}
 	expectedMeta := metav1.ObjectMeta{
-		Name:            "trigger-" + f1Name,
+		Name:            cronjobName,
 		Namespace:       ns,
 		OwnerReferences: or,
 		Labels: map[string]string{
@@ -81,7 +83,7 @@ func TestEnsureCronJob(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	cronJob, err := clientset.BatchV1beta1().CronJobs(ns).Get(fmt.Sprintf("trigger-%s", f1.Name), metav1.GetOptions{})
+	cronJob, err := clientset.BatchV1beta1().CronJobs(ns).Get(cronjobName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -127,7 +129,7 @@ func TestEnsureCronJob(t *testing.T) {
 	cronjobTriggerObj.Spec.Payload = newData
 
 	err = EnsureCronJob(clientset, f1, cronjobTriggerObj, "unzip", or, pullSecrets)
-	cronJob, err = clientset.BatchV1beta1().CronJobs(ns).Get(fmt.Sprintf("trigger-%s", f1.Name), metav1.GetOptions{})
+	cronJob, err = clientset.BatchV1beta1().CronJobs(ns).Get(cronjobName, metav1.GetOptions{})
 
 	runtimeContainer = cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
 	args = runtimeContainer.Args
@@ -143,7 +145,7 @@ func TestEnsureCronJob(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	updatedCronJob, err := clientset.BatchV1beta1().CronJobs(ns).Get(fmt.Sprintf("trigger-%s", f1.Name), metav1.GetOptions{})
+	updatedCronJob, err := clientset.BatchV1beta1().CronJobs(ns).Get(cronjobName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}


### PR DESCRIPTION
## ☕ Purpose

Based on #14 this PR aims to allow users to create multiple triggers to the same function. It moves from creating a static name interpolating the `trigger` with the function name, to using the `CronJobTrigger` resource (which is unique) instead.

## 🧐 Checklist

- [x] Changed naming pattern.
- [x] Updated the tests.