### PR TITLE
Customize cronjob's  service port

### DIFF
--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -60,7 +60,12 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, c
 
 	activeDeadlineSeconds := int64(timeout)
 	jobName := fmt.Sprintf("trigger-%s", funcObj.ObjectMeta.Name)
-	functionEndpoint := fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.ObjectMeta.Name, funcObj.ObjectMeta.Namespace)
+	functionPort := "8080"
+	if len(funcObj.Spec.ServiceSpec.Ports) != 0 {
+		functionPort = strconv.Itoa(int(funcObj.Spec.ServiceSpec.Ports[0].Port))
+	}
+
+	functionEndpoint := fmt.Sprintf("http://%s.%s.svc.cluster.local:%s", funcObj.ObjectMeta.Name, funcObj.ObjectMeta.Namespace, functionPort)
 
 	headersTemplate := "-H %s -H %s -H %s -H %s -H %s"
 	eventId := "\"Event-Id: $(POD_UID)\""


### PR DESCRIPTION
**Issue Ref**: closes https://github.com/kubeless/kubeless/issues/1102
 
**Description**: 

This PR allows modifying the service port in a function cronjob. Currently, it is hardcoded to `8080`; in this PR we modify this logic to use the first port defined in the function object.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [ ] Docs
